### PR TITLE
Example of using CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,14 @@
+# A CODEOWNERS file is used to define individuals or teams that 
+# are responsible for code in a repository.
+#
+# Code owners are automatically requested for review when someone 
+# opens a pull request that modifies code that they own. When 
+# someone with admin permissions has enabled required reviews, 
+# they can optionally require approval from a code owner.
+#
+# More information can be found here:
+# https://help.github.com/articles/about-codeowners/
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+*       @josh-

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ If you want to see how you're progressing, you can check out your stats at: [`ht
 
 The following is a sample list of projects that could be good candidates to contribute to. I will gladly accept pull requests to this repo so please feel free to [fork it](https://github.com/josh-/juniordev-hacktoberfest/fork) add your own below!
 
+### Example Files
+
+- [Example of a LICENSE file](LICENSE)
+
+- [Example of a CODEOWNERS file](CODEOWNERS)
+
 #### Documentation
 
 - [freeCodeCamp/guides](https://github.com/freeCodeCamp/guides)


### PR DESCRIPTION
A CODEOWNERS file is used to define individuals or teams that are responsible for code in a repository.

This is an example of how you can improve a project's code reviews process :) 